### PR TITLE
Added Discord sharding to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ pip install discord-ext-prometheus
 
 # Exposed Metrics
 
-| Name                           | Documentation                                 | Labels            |
-|--------------------------------|-----------------------------------------------|-------------------|
-| `discord_connected`            | Determines if the bot is connected to Discord | None              |
-| `discord_event_on_interaction` | Amount of interactions                        | `command`         |
-| `discord_event_on_command`     | Amount of commands                            | `command`         |
-| `discord_stat_total_guilds`    | Amount of guild this bot is a member of       | None              |
-| `discord_stat_total_channels`  | Amount of channels this bot is has access to  | None              |
-| `discord_stat_total_users`     | Amount of users this bot can see              | None              |
-| `discord_stat_total_commands`  | Amount of commands                            | None              |
-| `logging`                      | Log entries                                   | `logger`, `level` |
+| Name                           | Documentation                                 | Labels                            |
+|--------------------------------|-----------------------------------------------|-----------------------------------|
+| `discord_connected`            | Determines if the bot is connected to Discord | `shard`                           |
+| `discord_latency`              | latency to Discord                            | `shard`                           |
+| `discord_event_on_interaction` | Amount of interactions                        | `shard`, `interaction`, `command` |
+| `discord_event_on_command`     | Amount of commands                            | `shard`, `command`                |
+| `discord_stat_total_guilds`    | Amount of guild this bot is a member of       | None                              |
+| `discord_stat_total_channels`  | Amount of channels this bot is has access to  | None                              |
+| `discord_stat_total_users`     | Amount of users this bot can see              | None                              |
+| `discord_stat_total_commands`  | Amount of commands                            | None                              |
+| `logging`                      | Log entries                                   | `logger`, `level`                 |
 
 Notes:
-- `on_interaction` are application interactions such as slash commands
+- `on_interaction` are application interactions such as slash commands or modals
 - `on_command` are traditional message commands (usualy using the command prefix)
 
 # Grafana Dashboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "discord-ext-prometheus"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="Apollo-Roboto", email="Apollo_Roboto@outlook.com" },
 ]

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -1,5 +1,5 @@
 import unittest
-
+import asyncio
 from discord.ext.prometheus import PrometheusCog
 from discord.ext import commands
 from discord import Intents
@@ -10,9 +10,17 @@ class TestCog(unittest.TestCase):
 	"""
 
 	def test_can_be_instanciated(self):
-		bot = commands.Bot(
-			command_prefix='!',
-			intents=Intents.all()
-		)
+		event_loop = asyncio.new_event_loop()
+		asyncio.set_event_loop(event_loop)
 
-		PrometheusCog(bot)
+		async def run_test():
+			bot = commands.Bot(
+				command_prefix='!',
+				intents=Intents.all()
+			)
+
+			PrometheusCog(bot)
+
+		coro = asyncio.coroutine(run_test)
+		event_loop.run_until_complete(coro())
+		event_loop.close()


### PR DESCRIPTION
Changes:
- Added metric `discord_latency`
- Added shard label to `discord_event_on_interaction`, `discord_connected`, `discord_latency`, `discord_event_on_command`
- Updated a test to include the asyncio event loop