### PR TITLE
Using class `BotBase` instead of `Bot`

### DIFF
--- a/discord/ext/prometheus/prometheus_cog.py
+++ b/discord/ext/prometheus/prometheus_cog.py
@@ -3,6 +3,7 @@ from prometheus_client import start_http_server, Counter, Gauge
 from discord.ext import commands, tasks
 from discord import Interaction, InteractionType, AutoShardedClient
 from discord.app_commands.commands import Command
+from discord.ext.commands.bot import BotBase
 
 log = logging.getLogger("prometheus")
 
@@ -48,7 +49,7 @@ class PrometheusCog(commands.Cog):
     using the `on_ready` listener.
     """
 
-    def __init__(self, bot: commands.Bot, port: int = 8000):
+    def __init__(self, bot: BotBase, port: int = 8000):
         """
         Parameters:
                 bot: The Discord bot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "discord-ext-prometheus"
-version = "0.2.0"
+version = "0.2.1"
 authors = [{ name = "Apollo-Roboto", email = "Apollo_Roboto@outlook.com" }]
 description = "An extension for the discord.py library that enables Prometheus metrics"
 readme = "README.md"


### PR DESCRIPTION
Addresses issue #22

# Changes
- Using `BotBase` in `prometheus_cog`
- Version bump
